### PR TITLE
Remove potential existing pkg dir from a previous build

### DIFF
--- a/build-package
+++ b/build-package
@@ -7,6 +7,9 @@ STARTDIR="$(pwd)"
 DESTDIR="$STARTDIR/pkg"
 OUTDIR="$STARTDIR/deb"
 
+# Remove potential leftovers from a previous build
+rm -rf "$DESTDIR"
+
 # Install the package itself
 npm install -g --prefix "$DESTDIR/usr" thelounge@2.0.1
 


### PR DESCRIPTION
Not doing so outputs the unpleasant following, which may or may not be an issue. Either way, it should start fresh.

```sh
ln: failed to create symbolic link ‘/home/user/deb-lounge/pkg/lib/systemd/system/multi-user.target.wants/lounge.service’: File exists
mkdir: cannot create directory ‘/home/user/deb-lounge/pkg/DEBIAN’: File exists
mkdir: cannot create directory ‘/home/user/deb-lounge/deb’: File exists
```