### PR TITLE
Remove double-slash from last output of the build script

### DIFF
--- a/build-package
+++ b/build-package
@@ -33,4 +33,4 @@ grep -FRlZ "$STARTDIR" "$DESTDIR" | \
 # Build .deb
 mkdir "$DESTDIR/DEBIAN" "$OUTDIR"
 cp "$STARTDIR/debian/"* "$DESTDIR/DEBIAN/"
-dpkg-deb --build "$DESTDIR" "$OUTDIR/"
+dpkg-deb --build "$DESTDIR" "$OUTDIR"


### PR DESCRIPTION
Really not a big deal at all, but without this, last output is:

```sh
dpkg-deb: building package `lounge' in `/home/user/deb-lounge/deb//lounge_2.1.0-1_all.deb'.
```