### PR TITLE
Harden first cd command

### DIFF
--- a/build-package
+++ b/build-package
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname ${BASH_SOURCE[0]})
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
 # Some variables
 DEBVERSION=2.2.2-1


### PR DESCRIPTION
```
cd $(dirname ${BASH_SOURCE[0]})
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^-- SC2046: Quote this to prevent word splitting.
             ^-- SC2086: Double quote to prevent globbing and word splitting.
```