### PR TITLE
Automated package builds and uploads using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+sudo: required
+
+language: minimal
+
+install:
+  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  - sudo apt-get install -y nodejs
+
+before_script: ./build-package
+
+script: ./tests.sh
+
+deploy:
+  - provider: releases
+    repo: thelounge/lounge
+    api_key:
+      secure: U7v68GwbhCWHga2kwmgt+JnbujJGj4mC8yK58HvxSj2/u7OQI6vTdGssDfg0XFyOFcCzjfsup69yZLmXoLxSJOocNurt+CCgmAoPGF+qU3r3UsGU6TNvbxI4FbycHZ7JYB7A6wxdqz9FWKmtMpAXDVVZAnSqyrojqez7io54MaciaGFJp1VZf6L/VP9vQhghl4AX087SMLWKB2o8whUFzyKHpI8rajZj6zsQ9n9J10Wk2fmT6phK/glCOkrUUnds/IHmyz7LF9NiXxgMQsmkI6bqv8FgctMB5jWON7WzCcXcYZG7XrZne1YUIpTuukfAXhYiCjiDKaLADOk59oRcpPc/37x4yi0s8r/EFYEaz4wvcw9uzko/WSk1hQFVTNMlvQpDT2Bc5MdFyACPK/y/jgyKfO1uxiMYP6c9baSdTkjuMOO0ju6fnZTWrGsqnMvON85JE6xoA69VpWy8sylOksyd0/OysA6bjG8yZeUGSlLENy1ZcexAg+3G3s9ghkDROgANcZqAxHJQ2VjmcvQzScTSKtRnRXl56ZtPfhbthakUHwC9Pt3pgue8xQPf7nawB0B+LGhlkekiqOihfR1fBypqFMQyhlpETnJQLg7mlqMQvbw0GgxzBMlp4aAAjq077G5q4rJBS73CfSW25ndRJ1wLj88KIBsLqP+FSAHISkA=
+    file: deb/*.deb
+    file_glob: true
+    skip_cleanup: true
+    on:
+      repo: thelounge/deb-lounge
+      tags: true
+
+  - provider: releases
+    repo: thelounge/deb-lounge
+    api_key:
+      secure: U7v68GwbhCWHga2kwmgt+JnbujJGj4mC8yK58HvxSj2/u7OQI6vTdGssDfg0XFyOFcCzjfsup69yZLmXoLxSJOocNurt+CCgmAoPGF+qU3r3UsGU6TNvbxI4FbycHZ7JYB7A6wxdqz9FWKmtMpAXDVVZAnSqyrojqez7io54MaciaGFJp1VZf6L/VP9vQhghl4AX087SMLWKB2o8whUFzyKHpI8rajZj6zsQ9n9J10Wk2fmT6phK/glCOkrUUnds/IHmyz7LF9NiXxgMQsmkI6bqv8FgctMB5jWON7WzCcXcYZG7XrZne1YUIpTuukfAXhYiCjiDKaLADOk59oRcpPc/37x4yi0s8r/EFYEaz4wvcw9uzko/WSk1hQFVTNMlvQpDT2Bc5MdFyACPK/y/jgyKfO1uxiMYP6c9baSdTkjuMOO0ju6fnZTWrGsqnMvON85JE6xoA69VpWy8sylOksyd0/OysA6bjG8yZeUGSlLENy1ZcexAg+3G3s9ghkDROgANcZqAxHJQ2VjmcvQzScTSKtRnRXl56ZtPfhbthakUHwC9Pt3pgue8xQPf7nawB0B+LGhlkekiqOihfR1fBypqFMQyhlpETnJQLg7mlqMQvbw0GgxzBMlp4aAAjq077G5q4rJBS73CfSW25ndRJ1wLj88KIBsLqP+FSAHISkA=
+    file: deb/*.deb
+    file_glob: true
+    skip_cleanup: true
+    on:
+      repo: thelounge/deb-lounge
+      tags: true

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,8 +10,8 @@ fi
 if ! getent passwd lounge >/dev/null; then
 	adduser --quiet --system lounge \
 		--ingroup lounge \
-		--home /etc/lounge/ \
-		--gecos "lounge system user"
+		--no-create-home \
+		--gecos "System user for The Lounge (IRC client)"
 fi
 
 chown -R lounge:lounge /etc/lounge

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# Extract version to build from the repo
+DEBFILE="deb/lounge_`grep Version debian/control | awk -F': ' '{print $2}'`_all.deb"
+
+# Exit status code to update if there is a failure
+CODE=0
+
+echo
+echo $DEBFILE
+
+# The deb file should correctly exist
+if [ -e "$DEBFILE" ]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mwas correctly built\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ was not built\x1B[0m"
+  CODE=1
+fi
+
+# The file should have a minimum size for safety (ensures we did not create an
+# empty file), and a maximum size (ensures we did not load way too much
+# third-party code.
+if [ -e "$DEBFILE" ]; then
+  FILESIZE=`ls -l $DEBFILE | awk '{print $5}'`
+  HUMANSIZE=`ls -lh $DEBFILE | awk '{print $5}'`
+  MINSIZE=3
+  MAXSIZE=10
+
+  if [ "$FILESIZE" -gt "$(($MINSIZE * 1024 * 1024))" ] &&
+     [ "$FILESIZE" -lt "$(($MAXSIZE * 1024 * 1024))" ]; then
+    echo -e "  \x1B[32m✓\x1B[0m \x1B[90mhas a valid file size ($HUMANSIZE)\x1B[0m"
+  else
+    echo -e "  \x1B[31m✗ has an invalid file size\x1B[0m"
+    echo -e "      \x1B[32mminimum: ${MINSIZE}M\x1B[0m"
+    echo -e "      \x1B[32mmaximum: ${MAXSIZE}M\x1B[0m"
+    echo -e "      \x1B[31mactual:  ${HUMANSIZE}\x1B[0m"
+    CODE=1
+  fi
+else
+  echo -e "  \x1B[36m- file size could not be checked\x1B[0m"
+fi
+
+exit $CODE


### PR DESCRIPTION
## What this configuration does

- Downloads Node.js v8 using NodeSource.
  ⚠️ Note that `nvm` cannot be used because Node has to be installed system-wide.

- Builds the package (`deb/*.deb` file) like mentioned in the README

- Runs a couple tests to make sure that the file is correctly created, and is not empty (size of 0) or unexpectedly big (limit set to 10MB for now, which is pleeenty above the current 4MB files).
  💅 Bonus: Test output mentions the actual size ahead of time. See [this build](https://travis-ci.org/thelounge/deb-lounge/builds/340064517#L461) for example.
  ❓ Any suggestions for additional tests? The possibilities are rather limited at the moment though...

- When pushing a tag on this repo, uploads the built file to both `thelounge/lounge` and `thelounge/deb-lounge` (this repo).
  ⚠️ For this to work, the tag created on this repo **must** match the tag on the main repo. No big deal because that's the natural thing to do, but just to keep in mind (I use the same convention [on the website repo](https://github.com/thelounge/thelounge.github.io/releases) to build the changelog).
  - On `thelounge/lounge`, this will upload the file on the existing release
  - On this repo, it will create a GitHub release named after this tag before attaching the file. I hesitated not to upload to `thelounge/deb-lounge` but in the past people have missed that the packages are not on this repo, so I went for both to be safe, since it's free to do so. I can be convinced not to do so however, and instead add a mention in the README that built packages aren't here.

## What this configuration does not do

- The main things I was trying to achieve were uploading the package to GitHub, and testing that the built package installs and runs The Lounge correctly. Uploading works 👌, but there is no way to do the latter for now:
  - The package uses `systemd`/`systemctl` to run The Lounge, which is not available in Ubuntu 14.04, version that Travis uses. I have been discussing with their support, it's in the roadmap, but not there yet. Apart from that, `dpkg -i deb/*deb` works fine, I just can't test that TL is running.
  - When people ask for 16.04 support, they usually reply to use their Docker service... which does not support `systemd` (at least not without a ton of efforts, and not even sure).

  So I'll keep this as-is for now (file upload is more important right now anyway), and as soon as we can jump on 16.04, I'll do the other part.

- I didn't care for setting the release content on this repo yet (which doesn't support Markdown anyway so that's pretty useless) as that wasn't my main goal.

- I am only testing with Node 8 because at the moment this configuration only tests that the package builds correctly. When I can test that it can be installed and run, it will be useful to run it against multiple versions of Node.

## Other stuff

- I haven't squashed yet, but I will. I kept it as-is because I was exchanging emails with Travis support, and because I was bouncing back and forth with different solutions. It took me _a while_ to get there...

- This PR currently contains commit from #13 as I was testing stuff. I'll remove it before merging.

- In `postinst` step, I now do not create a home folder for the user for The Lounge. When I could install the package, it was flagged as an error, because `/etc/lounge` requires sudo permissions. I realized that this means [running the user config](https://github.com/thelounge/deb-lounge#user) is currently broken on `master`, so I went with not creating a home folder altogether. I've been [doing this from the beginning on `ansible-lounge`](https://github.com/astorije/ansible-lounge/blob/master/tasks/main.yml#L36) and it works fine.

- Everything in the current configuration has been tested. After tagging commits on this PR, I could see the file being uploaded in the main repo and this one. This is so cool. (I of course deleted uploaded files and tags/releases on this repo afterwards)