### PR TITLE
Use Ubuntu 16.04 (Xenial) in Travis, and use this to actually test that the package is correctly installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
+dist: xenial
 sudo: required
 
 language: minimal
 
+env:
+  # At the moment, only Node.js v8 is enabled, because of stability issues with
+  # Travis CI + Xenial causing builds to randomly fail. Bigger matrices mean
+  # higher chances of having some jobs failing.
+  # - NODE_VERSION=9 # Current stable
+  - NODE_VERSION=8 # Active LTS until April 2019
+  # - NODE_VERSION=6 # Active LTS until April 2018
+
 install:
-  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  - curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 
-before_script: ./build-package
+before_script:
+  - ./build-package
+  - sudo dpkg -i deb/*.deb
 
-script: ./tests.sh
+script:
+  - ./tests.sh
+  - sudo systemctl --full status lounge.service
 
 deploy:
   - provider: releases
@@ -19,6 +32,7 @@ deploy:
     file_glob: true
     skip_cleanup: true
     on:
+      condition: "$NODE_VERSION = 8"
       repo: thelounge/deb-lounge
       tags: true
 
@@ -30,5 +44,6 @@ deploy:
     file_glob: true
     skip_cleanup: true
     on:
+      condition: "$NODE_VERSION = 8"
       repo: thelounge/deb-lounge
       tags: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # Debian/Ubuntu package for The Lounge
 
+<a href="https://travis-ci.org/thelounge/deb-lounge">
+	<img
+		alt="Travis CI Build Status"
+		src="https://img.shields.io/travis/thelounge/deb-lounge/master.svg?style=flat-square">
+</a>
+
 This repository holds out the build scripts that generates our `.deb` precompiled packages and also tracks Debian-specific issues in relation to the packaging.
 
 
 ## Installation
+
 If you are looking to simply install The Lounge, please use our pre-compiled binary .deb files available in the releases section of the main project. This section assumes you want to build a Debian package from sources.
 
 ```sh

--- a/systemd/system.service
+++ b/systemd/system.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The Lounge IRC client
+Description=The Lounge (IRC client)
 After=network.target
 
 [Service]

--- a/systemd/user.service
+++ b/systemd/user.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The Lounge IRC client
+Description=The Lounge (IRC client)
 
 [Service]
 Type=simple

--- a/tests.sh
+++ b/tests.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-set -e
 
 # Extract version to build from the repo
-DEBFILE="deb/lounge_`grep Version debian/control | awk -F': ' '{print $2}'`_all.deb"
+DEBVERSION=`grep Version debian/control | awk -F': ' '{print $2}'`
+DEBFILE="deb/lounge_${DEBVERSION}_all.deb"
+NPMVERSION=`echo "${DEBVERSION}" | sed -E 's/-[0-9]+$//'`
 
 # Exit status code to update if there is a failure
 CODE=0
@@ -35,10 +36,116 @@ if [ -e "$DEBFILE" ]; then
     echo -e "      \x1B[32mminimum: ${MINSIZE}M\x1B[0m"
     echo -e "      \x1B[32mmaximum: ${MAXSIZE}M\x1B[0m"
     echo -e "      \x1B[31mactual:  ${HUMANSIZE}\x1B[0m"
+    echo
     CODE=1
   fi
 else
   echo -e "  \x1B[36m- file size could not be checked\x1B[0m"
+fi
+
+# If the service was correctly set up with systemd, it should show in the big
+# `sudo systemctl` list.
+SYSTEMCTL_LIST=`sudo systemctl | grep "lounge.service"`
+if [[ "$SYSTEMCTL_LIST" = *"The Lounge (IRC client)"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mcorrectly shows up in systemctl list\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ was not found or incorrectly listed\x1B[0m"
+  echo -e "      \x1B[32mexpected: The Lounge (IRC client)\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_LIST}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+# Wait until The Lounge is actually fully started
+sleep 2
+# Entire entry for the service. We'll use this to see if everything is in order.
+SYSTEMCTL_STATUS=`sudo systemctl status --full lounge.service`
+
+# `systemctl status` should report `Active: active (running) since ...`
+SYSTEMCTL_ACTIVE=`echo "${SYSTEMCTL_STATUS}" | grep "Active:"`
+if [[ "$SYSTEMCTL_ACTIVE" = *"active (running)"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mis reported as active and running by systemctl status\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not have a status of active and running\x1B[0m"
+  echo -e "      \x1B[32mexpected: Active: active (running)\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_ACTIVE}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+SYSTEMCTL_STARTED=`echo "${SYSTEMCTL_STATUS}" | grep "systemd\["`
+if [[ "$SYSTEMCTL_STARTED" = *"Started The Lounge (IRC client)"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mshows up as started in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not show up as started in systemctl\x1B[0m"
+  echo -e "      \x1B[32mexpected: Started The Lounge (IRC client)\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_STARTED}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+SYSTEMCTL_VERSION=`echo "${SYSTEMCTL_STATUS}" | grep "The Lounge v"`
+if [[ "$SYSTEMCTL_VERSION" = *"$NPMVERSION"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mshows correct version in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not show up correct version in systemctl\x1B[0m"
+  echo -e "      \x1B[32mexpected: The Lounge v$NPMVERSION\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_VERSION}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+SYSTEMCTL_CONFIG=`echo "${SYSTEMCTL_STATUS}" | grep "Configuration file:"`
+if [[ "$SYSTEMCTL_CONFIG" = *"/etc/lounge/config.js"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mshows correct configuration path in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not show up correct version in systemctl logs\x1B[0m"
+  echo -e "      \x1B[32mexpected: Configuration file: /etc/lounge/config.js\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_CONFIG}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+SYSTEMCTL_URL=`echo "${SYSTEMCTL_STATUS}" | grep "Available at"`
+if [[ "$SYSTEMCTL_URL" = *"http://:::9000/"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mshows correct URL in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not show up correct URL in systemctl logs\x1B[0m"
+  echo -e "      \x1B[32mexpected: Available at http://:::9000/\x1B[0m"
+  echo -e "      \x1B[31mactual:   ${SYSTEMCTL_URL}\x1B[0m"
+  echo
+  CODE=1
+fi
+
+SYSTEMCTL_LOGS=`echo "${SYSTEMCTL_STATUS}" | grep "thelounge\["`
+
+if [[ "$SYSTEMCTL_LOGS" != *"[WARN]"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mdoes not have any warnings in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ has warnings in systemctl in systemctl logs\x1B[0m"
+  echo -e "      \x1B[31mactual:   `echo "${SYSTEMCTL_LOGS}" | grep "\[WARN\]"`\x1B[0m"
+  echo
+  CODE=1
+fi
+
+if [[ "$SYSTEMCTL_LOGS" != *"[ERROR]"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mdoes not have any errors in systemctl logs\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ has errors in systemctl in systemctl logs\x1B[0m"
+  echo -e "      \x1B[31mactual:   `echo "${SYSTEMCTL_LOGS}" | grep "\[ERROR\]"`\x1B[0m"
+  echo
+  CODE=1
+fi
+
+THELOUNGE_HTML=`curl --silent http://localhost:9000`
+if [[ "$THELOUNGE_HTML" = *"<title>The Lounge</title>"* ]]; then
+  echo -e "  \x1B[32m✓\x1B[0m \x1B[90mreturns correct HTML markup when calling the webserver\x1B[0m"
+else
+  echo -e "  \x1B[31m✗ does not return correct HTML markup when calling the webserver\x1B[0m"
+  echo -e "      \x1B[32mexpected: <title>The Lounge</title>\x1B[0m"
+  echo -e "      \x1B[31mactual:\x1B[0m"
+  echo "$THELOUNGE_HTML"
+  CODE=1
 fi
 
 exit $CODE


### PR DESCRIPTION
- ~Tests our deb against all supported versions of Node (except v4, which is deprecated and therefore has warnings, it will be removed by next release anyway)~ Now only test against Node.js v8 because Travis is fairly unstable with Xenial for now
- Xenial is currently pre-prod but Travis support shared with me that I could use this. Since Xenial is the first Ubuntu version with systemd, and our deb relies on it, I can use it to actually install the package and make sure the server is running and serving web pages.
- New tests include: making sure the service is registered with systemd, making sure it is correctly started and at the correct version, making sure the CLI output did not raise any warning or error, making sure the webserver actually serves the HTML page.
- I also display the status/logs of the service, which could be useful in case something breaks.
- README badge

Xenial startup on Travis is not super stable at the moment (or maybe it's just Travis as a whole right now), so I'm tempted to remove 1 (v6) or 2 (v6 and v9) Node versions in the matrix. I'll rebuild a couple times to see how fragile/robust their Xenial support is, and I'll see what to do then.

Examples:
- Successful build: https://travis-ci.org/thelounge/deb-lounge/builds/342226241
- Unsuccessful build (breaking on purpose, so do not worry about values, it is more about the format): https://travis-ci.org/thelounge/deb-lounge/builds/342222866