### PR TITLE
Set up the repo for v3.0.0-pre.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script:
   - ./tests.sh
-  - sudo systemctl --full status lounge.service
+  - sudo systemctl --full status thelounge.service
 
 deploy:
   - provider: releases

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 This repository holds out the build scripts that generates our `.deb` precompiled packages and also tracks Debian-specific issues in relation to the packaging.
 
-
-## Installation
+## Building and installing the package
 
 If you are looking to simply install The Lounge, please use our pre-compiled binary .deb files available in the releases section of the main project. This section assumes you want to build a Debian package from sources.
 
@@ -30,29 +29,26 @@ After this, you should have a nice `.deb` file in the `deb/` output folder! This
 
 ### Configuration
 
-The default system-wide documentation file is located at `/etc/lounge/config.js`. Please note that user profiles and their IRC passwords are also stored there, so the directory is only readable by the `lounge` user.
-
+The default system-wide documentation file is located at `/etc/thelounge/config.js`. Please note that user profiles and their IRC passwords are also stored there, so the directory is only readable by the `thelounge` user.
 
 ### Running
 
 The Lounge provides both a system-wide and per-user systemd unit. If you installed the package, The Lounge should already be running and accessible on `http://127.0.0.1:9000`.
 
-
 #### System
 
-Simply enable the `lounge.service` unit, and your server should be up and running:
+Simply enable the `thelounge.service` unit, and your server should be up and running:
 
 ```sh
-systemctl enable --now lounge.service
+systemctl enable --now thelounge.service
 ```
-
 
 #### User
 
 If you do not want to run the software system-wide, or host multiple users that wish to host their own instance of The Lounge, it can also be launched per user:
 
 ```sh
-systemctl --user enable --now lounge.service
+systemctl --user enable --now thelounge.service
 ```
 
 Please note that for The Lounge to start on boot in this scenario, you will also require to have [lingering](https://wiki.archlinux.org/index.php/Systemd/User#Automatic_start-up_of_systemd_user_instances) enabled for this user:

--- a/build-package
+++ b/build-package
@@ -14,23 +14,23 @@ rm -rf "$DESTDIR"
 npm install -g --prefix "$DESTDIR/usr" thelounge@${NPMVERSION}
 
 # Write .thelounge_home to set correct system config directory
-echo "/etc/lounge" > "$DESTDIR/usr/lib/node_modules/thelounge/.thelounge_home"
+echo "/etc/thelounge" > "$DESTDIR/usr/lib/node_modules/thelounge/.thelounge_home"
 
 # Install configuration/home directory
-install -dm775 "$DESTDIR/etc/lounge"
-install -dm770 "$DESTDIR/etc/lounge/users"
+install -dm775 "$DESTDIR/etc/thelounge"
+install -dm770 "$DESTDIR/etc/thelounge/users"
 install -Dm660 \
 	"$DESTDIR/usr/lib/node_modules/thelounge/defaults/config.js" \
-	"$DESTDIR/etc/lounge/config.js"
+	"$DESTDIR/etc/thelounge/config.js"
 
 # Install systemd units
 install -Dm644 "$STARTDIR/systemd/system.service" \
-	"$DESTDIR/lib/systemd/system/lounge.service"
+	"$DESTDIR/lib/systemd/system/thelounge.service"
 install -Dm644 "$STARTDIR/systemd/user.service" \
-	"$DESTDIR/usr/lib/systemd/user/lounge.service"
+	"$DESTDIR/usr/lib/systemd/user/thelounge.service"
 install -dm755 "$DESTDIR/lib/systemd/system/multi-user.target.wants"
-ln -s "../lounge.service" \
-	"$DESTDIR/lib/systemd/system/multi-user.target.wants/lounge.service"
+ln -s "../thelounge.service" \
+	"$DESTDIR/lib/systemd/system/multi-user.target.wants/thelounge.service"
 
 # Remove all references to the build directory/host
 grep -FRlZ "$STARTDIR" "$DESTDIR" | \

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,8 @@
-Package: lounge
-Version: 2.7.1-1
+Package: thelounge
+Version: 3.0.0-pre.1-1
 Section: net
 Priority: optional
 Architecture: all
-Depends: nodejs (>= 4), bash
+Depends: nodejs (>= 6), bash
 Maintainer: Maxime Poulin <thelounge@max-p.me>
 Description: A self-hosted, web-based IRC client

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,17 +3,17 @@ set -e
 
 [[ "$1" == "configure" ]] || exit 0
 
-if ! getent group lounge >/dev/null; then
-	addgroup --quiet --system lounge
+if ! getent group thelounge >/dev/null; then
+	addgroup --quiet --system thelounge
 fi
 
-if ! getent passwd lounge >/dev/null; then
-	adduser --quiet --system lounge \
-		--ingroup lounge \
+if ! getent passwd thelounge >/dev/null; then
+	adduser --quiet --system thelounge \
+		--ingroup thelounge \
 		--no-create-home \
 		--gecos "System user for The Lounge (IRC client)"
 fi
 
-chown -R lounge:lounge /etc/lounge
+chown -R thelounge:thelounge /etc/thelounge
 systemctl daemon-reload
-systemctl start lounge.service
+systemctl start thelounge.service

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,2 +1,2 @@
 #!/bin/bash
-systemctl stop lounge.service
+systemctl stop thelounge.service

--- a/systemd/system.service
+++ b/systemd/system.service
@@ -3,8 +3,8 @@ Description=The Lounge (IRC client)
 After=network.target
 
 [Service]
-User=lounge
-Group=lounge
+User=thelounge
+Group=thelounge
 Type=simple
 ExecStart=/usr/bin/thelounge start
 ProtectSystem=yes

--- a/systemd/user.service
+++ b/systemd/user.service
@@ -3,7 +3,7 @@ Description=The Lounge (IRC client)
 
 [Service]
 Type=simple
-ExecStart=THELOUNGE_HOME=~/.lounge /usr/bin/thelounge start
+ExecStart=THELOUNGE_HOME=~/.thelounge /usr/bin/thelounge start
 
 [Install]
 WantedBy=default.target

--- a/tests.sh
+++ b/tests.sh
@@ -2,7 +2,7 @@
 
 # Extract version to build from the repo
 DEBVERSION=`grep Version debian/control | awk -F': ' '{print $2}'`
-DEBFILE="deb/lounge_${DEBVERSION}_all.deb"
+DEBFILE="deb/thelounge_${DEBVERSION}_all.deb"
 NPMVERSION=`echo "${DEBVERSION}" | sed -E 's/-[0-9]+$//'`
 
 # Exit status code to update if there is a failure
@@ -45,7 +45,7 @@ fi
 
 # If the service was correctly set up with systemd, it should show in the big
 # `sudo systemctl` list.
-SYSTEMCTL_LIST=`sudo systemctl | grep "lounge.service"`
+SYSTEMCTL_LIST=`sudo systemctl | grep "thelounge.service"`
 if [[ "$SYSTEMCTL_LIST" = *"The Lounge (IRC client)"* ]]; then
   echo -e "  \x1B[32m✓\x1B[0m \x1B[90mcorrectly shows up in systemctl list\x1B[0m"
 else
@@ -59,7 +59,7 @@ fi
 # Wait until The Lounge is actually fully started
 sleep 2
 # Entire entry for the service. We'll use this to see if everything is in order.
-SYSTEMCTL_STATUS=`sudo systemctl status --full lounge.service`
+SYSTEMCTL_STATUS=`sudo systemctl status --full thelounge.service`
 
 # `systemctl status` should report `Active: active (running) since ...`
 SYSTEMCTL_ACTIVE=`echo "${SYSTEMCTL_STATUS}" | grep "Active:"`
@@ -96,11 +96,11 @@ else
 fi
 
 SYSTEMCTL_CONFIG=`echo "${SYSTEMCTL_STATUS}" | grep "Configuration file:"`
-if [[ "$SYSTEMCTL_CONFIG" = *"/etc/lounge/config.js"* ]]; then
+if [[ "$SYSTEMCTL_CONFIG" = *"/etc/thelounge/config.js"* ]]; then
   echo -e "  \x1B[32m✓\x1B[0m \x1B[90mshows correct configuration path in systemctl logs\x1B[0m"
 else
   echo -e "  \x1B[31m✗ does not show up correct version in systemctl logs\x1B[0m"
-  echo -e "      \x1B[32mexpected: Configuration file: /etc/lounge/config.js\x1B[0m"
+  echo -e "      \x1B[32mexpected: Configuration file: /etc/thelounge/config.js\x1B[0m"
   echo -e "      \x1B[31mactual:   ${SYSTEMCTL_CONFIG}\x1B[0m"
   echo
   CODE=1


### PR DESCRIPTION
- ~Install Yarn as part of the Travis build~ **EDIT:** Not anymore...
- Rename the services from `lounge.service` to `thelounge.service`
- Rename the config folder from `lounge` to `thelounge`
- Rename the system user from `lounge` to `thelounge`
- ~Use Yarn to install the dependencies~ **EDIT:** Not anymore, Yarn doesn't play well with global packages (prefix is useless, essentially), and can't prefix local packages
- Update the deb version to `3.0.0-pre.1-1`
- Require Node.js v6 as minimum version
- Rename the deb files from `lounge_[version]_all.deb`  to `thelounge_[version]_all.deb`
- Update the tests accordingly