### PR TITLE
Add website and issue tracker URLs to the control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,3 +6,5 @@ Architecture: all
 Depends: nodejs (>= 6), bash
 Maintainer: Maxime Poulin <thelounge@max-p.me>
 Description: A self-hosted, web-based IRC client
+Homepage: https://thelounge.chat
+Bugs: https://github.com/thelounge/thelounge/issues


### PR DESCRIPTION
I also looked if it was possible to change maintainer from individual+email to our GitHub organization + website, but apparently it is rather stricly enforced that way.